### PR TITLE
add quill:options event

### DIFF
--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -98,6 +98,7 @@ export default class _Class extends Controller {
     if (null !== heightDefined) {
       this.editorContainerTarget.style.height = heightDefined;
     }
+    this.dispatchEvent('options', options);
     const quill = new Quill(this.editorContainerTarget, options);
     quill.on('text-change', () => {
       const quillContent = quill.root.innerHTML;

--- a/assets/src/controller.ts
+++ b/assets/src/controller.ts
@@ -141,6 +141,8 @@ export default class extends Controller {
             this.editorContainerTarget.style.height = heightDefined
         }
 
+        this.dispatchEvent('options', options);
+
         const quill = new Quill(this.editorContainerTarget, options);
         quill.on('text-change', () => {
             const quillContent = quill.root.innerHTML;


### PR DESCRIPTION
Hello there !

Great bundle.

I wanted to install the quill mention module, but one of the options has to be a javascript callback: so it's not possible to add this module via php

I therefore propose to add an event just before the editor is created, to manipulate the options (and therefore add a module)

This then allows you to do something like :

```js
import { Controller } from "@hotwired/stimulus";
import Quill from "quill";
import { Mention, MentionBlot } from "quill-mention";

Quill.register({ "blots/mention": MentionBlot, "modules/mention": Mention });

export default class extends Controller {
  connect() {
    this.element.addEventListener("quill:options", this._onOptions);
  }

  disconnect() {
    this.element.removeEventListener("quill:options", this._onOptions);
  }

  _onOptions(event) {
    const options = event.detail;
    Object.assign(options.modules, {
      "mention": {
        allowedChars: /^[A-Za-z\sÅÄÖåäö]*$/,
        mentionDenotationChars: ["@", "#"],
        source: function(searchTerm, renderList, mentionChar) {
          renderList(..., searchTerm);
        }
      }
    });
  }
}
```

