### PR TITLE
reorder assetMapper modules import because of https://github.com/Ehyi…

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -19,14 +19,13 @@
         },
         "importmap": {
             "@hotwired/stimulus": "^3.0.0",
-            "file-loader": "^6.2.0",
+            "quill2-emoji": "^0.1.2",
+            "quill2-emoji/dist/style.css": "^0.1.2",
             "quill": "2.0.3",
             "quill/dist/quill.snow.css": "2.0.3",
             "quill/dist/quill.bubble.css": "2.0.3",
             "axios": "^1.4.0",
-            "quill2-emoji": "^0.1.2",
-            "quill2-emoji/dist/style.css": "^0.1.2",
-            "quill-resize-image": "^1.0.4"
+            "quill-resize-image": "^1.0.5"
         }
     },
     "scripts": {
@@ -55,7 +54,6 @@
         "eslint": "^8.1.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-plugin-jest": "^25.2.2",
-        "quill2-emoji": "^0.1.2",
         "ts-loader": "^9.0.0",
         "typescript": "^4.9.5",
         "webpack": "^5.74.0",
@@ -63,19 +61,17 @@
         "webpack-notifier": "^1.15.0"
     },
     "peerDependencies": {
-        "@hotwired/stimulus": "^3.0.0",
-        "axios": "^1.4.0",
-        "file-loader": "^6.2.0",
-        "quill": "2.0.3"
+        "@hotwired/stimulus": "^3.0.0"
     },
     "dependencies": {
+        "@hotwired/stimulus": "^3.0.0",
         "axios": "^1.4.0",
         "eventemitter3": "^5.0.1",
         "file-loader": "^6.2.0",
         "lodash-es": "^4.17.21",
         "quill": "2.0.3",
         "quill-delta": "^5.1.0",
-        "quill-resize-image": "^1.0.4",
+        "quill-resize-image": "^1.0.5",
         "quill2-emoji": "^0.1.2"
     },
     "eslintConfig": {

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1043,7 +1043,7 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@hotwired/stimulus@^3.2.1":
+"@hotwired/stimulus@^3.0.0":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
@@ -4677,10 +4677,10 @@ quill-delta@^5.1.0:
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
 
-quill-resize-image@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/quill-resize-image/-/quill-resize-image-1.0.4.tgz#d199629e1265dced74d21e0a5814ffcbf1b8c6d8"
-  integrity sha512-CwFFRe1Wvtn9gfmUQ2Cj6R+l2VSpBKv1xGVScKiAtkljHKZx94jatJTedpw9HGN4mdWOu8AZfgIDCtkeQrmiBA==
+quill-resize-image@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/quill-resize-image/-/quill-resize-image-1.0.5.tgz#072533bad859d38d21056fd5ac6600841a62c5fc"
+  integrity sha512-s6yinBoRXy9jsVXdK9J8WMfv4DUO6yE0uzzBWTjOu4JwcSqzlsgYivB5KCWoPAOrdxmV1mYpvvALCWa36r5Mnw==
 
 quill2-emoji@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
…ah/ux-quill/issues/49

quill2-emoji requires a 2.0.0-dev4 version of quill, and when fresh installing with assetMapper got a problem where quill2-emoji version was overwriting quill setted version. && update quill_resize_image version